### PR TITLE
Fixes to GitHub pushrelease workflow files

### DIFF
--- a/.github/workflows/pushrelease.yml
+++ b/.github/workflows/pushrelease.yml
@@ -40,6 +40,11 @@ jobs:
             any::rcmdcheck
             any::covr
             any::remotes
+            any::lubridate
+            any::tibble
+            any::dplyr
+            any::knitr
+            any::kableExtra
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2
@@ -66,23 +71,18 @@ jobs:
         run: Rscript -e "covr::codecov()"
 
   release:
-    name: Bump version and release
-    needs: build
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout one
-        uses: actions/checkout@master
+    name: Bump version
+    build:
+     runs-on: ubuntu-latest
+     steps:
+      - uses: actions/checkout@v2
         with:
           fetch-depth: '0'
-
       - name: Bump version and push tag
-        id: newtag
-        uses: anothrNick/github-tag-action@1.39.0
+        uses: anothrNick/github-tag-action@1.36.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
-          DEFAULT_BUMP: patch
-          RELEASE_BRANCHES: main
 
       - name: Checkout two
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -453,10 +453,10 @@ max
 2012-01-12
 </td>
 <td style="text-align:left;">
-2012-01-12
+2012-01-13
 </td>
 <td style="text-align:left;">
-2012-01-12
+2012-01-13
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
For more information on changes in this release, please see previous PR https://github.com/globalgov/messydates/pull/50 .
