### PR TITLE
Fixes additional issues with pushrelease workflow files

### DIFF
--- a/.github/workflows/pushrelease.yml
+++ b/.github/workflows/pushrelease.yml
@@ -159,6 +159,7 @@ jobs:
         with:
           cache-version: 2
           extra-packages: |
+            any::messydates
             any::lubridate
             any::tibble
             any::dplyr

--- a/.github/workflows/pushrelease.yml
+++ b/.github/workflows/pushrelease.yml
@@ -76,6 +76,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Bump version and push tag
+        id: newtag
         uses: anothrNick/github-tag-action@1.39.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.Rmd
+++ b/README.Rmd
@@ -84,7 +84,7 @@ pkg_comparison <- tibble::tribble(~Example, ~OriginalDate,
                                     "Set of dates", "2021-5-26, 2021-11-19, 2021-12-4") %>%
   dplyr::mutate(base = as.Date(OriginalDate),
                 lubridate = lubridate::as_date(OriginalDate),
-                messydates = messydates::as_messydate(OriginalDate))
+                messydates = as_messydate(OriginalDate))
 ```
 
 ```{r compprint, echo=FALSE, results='asis'}

--- a/README.Rmd
+++ b/README.Rmd
@@ -53,6 +53,7 @@ However, this can create inferential issues when timing or sequence is important
 with various kinds of date imprecision.
 
 ```{r setup, echo=FALSE}
+library(messydates)
 library(lubridate)
 library(tibble)
 library(dplyr)
@@ -84,7 +85,7 @@ pkg_comparison <- tibble::tribble(~Example, ~OriginalDate,
                                     "Set of dates", "2021-5-26, 2021-11-19, 2021-12-4") %>%
   dplyr::mutate(base = as.Date(OriginalDate),
                 lubridate = lubridate::as_date(OriginalDate),
-                messydates = as_messydate(OriginalDate))
+                messydates = messydates::as_messydate(OriginalDate))
 ```
 
 ```{r compprint, echo=FALSE, results='asis'}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ working with various kinds of date imprecision.
 
     #> 
     #> Attaching package: 'lubridate'
+    #> The following objects are masked from 'package:messydates':
+    #> 
+    #>     day, month, year
     #> The following objects are masked from 'package:base':
     #> 
     #>     date, intersect, setdiff, union


### PR DESCRIPTION
For more information on changes in this release, please see previous PR https://github.com/globalgov/messydates/pull/50 .
