### PR TITLE
Updated how ´contract()´ function checks if 'mdate' object has been expanded 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .RData
 .Ruserdata
 docs
+CRAN-SUBMISSION
 iso_standards*
 *.DS_Store
 article/article.log

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,8 +9,8 @@ Description: Contains a set of tools for constructing and coercing
   date ranges, and sets of dates. 
   This is useful for describing and analysing temporal information,
   whether historical or recent, where date precision may vary.
-Version: 0.3.4
-Date: 2023-01-19
+Version: 0.3.5
+Date: 2023-01-20
 Authors@R: 
     c(person(given = "James",
              family = "Hollway",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# messydates 0.3.5
+
+## Functions
+
+* Updated how ´contract()´ function checks if 'mdate' object has been expanded 
+
 # messydates 0.3.4
 
 ## Package

--- a/R/contract.R
+++ b/R/contract.R
@@ -22,7 +22,7 @@
 #' tibble::tibble(d, contract(d))
 #' @export
 contract <- function(x, collapse = TRUE) {
-  if (class(x) != "list") {
+  if (!inherits(x, 'list')) {
     x <- expand(x)
   }
   x <- compact_negative_dates(x)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,7 +1,3 @@
-This is a resubmission. In this version I have:
-
-* Moved cheatsheet.pdf to 'inst' folder instead of the 'man' folder
-
 ## Test environments
 
 * local R installation, x86_64-apple-darwin17.0, R 4.2.0

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,8 @@
+This is a resubmission. In this version I have:
+
+Updated how ´contract()´ function checks if 'mdate' object has been expanded
+to avoid comparing class to string
+
 ## Test environments
 
 * local R installation, x86_64-apple-darwin17.0, R 4.2.0


### PR DESCRIPTION
# Description

This patch PR fixes issues with class and string comparison for CRAN resubmission by updating ´contract()´ function.

## Functions

* Updated how ´contract()´ function checks if 'mdate' object has been expanded 

# Checklist:

- [ ] PR form
  - [ ] I have given this pull request an informative title
  - [ ] Description above itemizes changes under subtitles, e.g. "## Collection""
  - [ ] Any closed, fixed, or related issues are referenced and explained in the description above, e.g. "Fixed #0 by adding A"
  - [ ] Package builds on my OS without issues
- [ ] PR checks all pass for latest commit
  - [ ] Package builds on Mac
  - [ ] Package builds on Windows
  - [ ] Package builds on Linux
  - [ ] CodeCov check: Package improves or maintains good test coverage
  - [ ] CodeFactor check: Package improves or maintains good style
- [ ] Documentation
  - [ ] Any new or modified functions or data have roxygen style documentation in their .R scripts
  - [ ] Any longer functions are commented inline so that it is easier to debug in the future
  - [ ] PR description above and the NEWS.md file are aligned
  - [ ] DESCRIPTION file version is bumped by the appropriate increment (major, minor, patch)
